### PR TITLE
Add project status to About

### DIFF
--- a/_pages/about.markdown
+++ b/_pages/about.markdown
@@ -4,7 +4,15 @@ title: About
 permalink: /about/
 ---
 We're a WiiConnect24 replacement intended to be a better fit for the community and developers than other WiiConnect24 replacements. The name was provided by Twin_Turbo (@Twin_Turbo#8726 on Discord) -- thanks to them!
-Our Discord server can be found at <coming soon>
+Our Discord server can be found at \<coming soon>  
+
+<br>
+
+Current project status: in heavy initial development.
+We plan to have:
+- Mail, EVC voting, announcement services provided by Google App Engine
+- Serving of static forecast, news, evc data soon off of either flexible App Engine or Compute Engine.
+   
  
  **Contributors**
  


### PR DESCRIPTION
Also escape `<coming soon>` so it shows up on the website. I *think* that's how it was intended to be.